### PR TITLE
Update and pin mypy-protobuf plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ apt-get install -qyy \
     -o APT::Install-Suggests=false \
     dos2unix python3-dev python3-pip
 
-pip3 install --break-system-package mypy-protobuf
+pip3 install --break-system-package --no-cache-dir --compile mypy-protobuf==4.0.0
 apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOT


### PR DESCRIPTION
Latest mypy-protobuf has an option to generate only sync stubs, so we won't need our post-processing hack anymore